### PR TITLE
Update hierarchy.R

### DIFF
--- a/R/hierarchy.R
+++ b/R/hierarchy.R
@@ -35,6 +35,6 @@ hierarchy = function(m, quadrants = NULL, log.scale = T) {
     if (!log.scale) dat = dplyr::transmute(dat, X = x, Y = y)
     else dat = dplyr::transmute(dat, X = x.scaled, Y = y.scaled)
     rownames(dat) = rows
-    class(dat) = append(class(dat), 'hierarchy')
+    #class(dat) = append(class(dat), 'hierarchy')
     dat
 }


### PR DESCRIPTION
Line 38 which adds an additional class type to the data structure does not play well with other functions (such as gghighlight), so removal of the line keeps the data structure as a data.frame which avoids downstream errors.  I only commented the line out, but it could likely be removed. Unless the removal of this line results in conflicts in other scrabble specific functions. Removal fixed my problems.